### PR TITLE
Discard trailing whitespace on plain elements

### DIFF
--- a/lib/YAMLish.pm6
+++ b/lib/YAMLish.pm6
@@ -466,7 +466,7 @@ grammar Grammar {
 			make ' ';
 		}
 		method plain($/) {
-			make self!handle_properties($<properties>, $/, ~$/);
+			make self!handle_properties($<properties>, $/, $/.Str.subst(/<[\ \t]>+$/, ''));
 		}
 		method inline-plain($/) {
 			make ~$<value>

--- a/t/basic.t
+++ b/t/basic.t
@@ -115,4 +115,7 @@ END
 my $expected4 = "foo";
 is(load-yaml($text4), $expected4, 'Tags and directives seem to work');
 
+my $text5 = "foo: bar  \n";
+is-deeply load-yaml($text5), { foo => 'bar' }, 'Trailing whitespae in plain mode is discarded';
+
 done-testing();


### PR DESCRIPTION
Per section 7.3.3 in the YAML 1.2 spec:

> All leading and trailing white space characters are excluded from the
> content.

This implements that by trimming it off if it appears.