### PR TITLE
Openapi: 3.0.1 does not parse

### DIFF
--- a/t/openapi.t
+++ b/t/openapi.t
@@ -1,0 +1,13 @@
+#! perl6
+
+use v6;
+use Test;
+use YAMLish;
+
+my $text1 = 'openapi: 3.0.1';
+
+my $match = load-yaml($text1);
+my %expected = (openapi => '3.0.1');
+is-deeply($match, %expected); 
+
+done-testing();


### PR DESCRIPTION
"openapi: 3.0.1" is correct yaml, yet it does not parse.

