### PR TITLE
Fix the escaping of double quotes.

### DIFF
--- a/lib/YAMLish.pm6
+++ b/lib/YAMLish.pm6
@@ -1020,7 +1020,7 @@ multi to-yaml(Str:D  $d where /^ <!Schema::Core::element> <[\w.-]>+ $/; $ = Str)
 	return $d;
 }
 multi to-yaml(Str:D  $d; $) {
-	return '"' ~ escape-chars($d).trans('"' => '\"') ~ '"'
+	return '"' ~ escape-chars($d).trans(['"'] => ['\"']) ~ '"'
 }
 multi to-yaml(Positional:D $d, Str $indent) {
 	return ' []' unless $d.elems;

--- a/t/roundtrip.t
+++ b/t/roundtrip.t
@@ -10,6 +10,8 @@ my @data = (
 	42.005,
 	True,
 	False,
+	'A string containing a single (") double quote.',
+	"A string containing both 'single' and \"double\" quotes.",
 	"A multiline\nstring.\n",
 	"  A multiline \n   string with varying\n  indentation.\n",
 	[1, 2, 3],


### PR DESCRIPTION
Hi,

Thanks for writing and maintaining YAMLish!

What do you think about this trivial fix? To get a multi-character replacement from Str.trans(), we need to pass a list of pairs to replace.

Thanks again for your work on Perl and Raku!

G'luck,
Peter
