### PR TITLE
add utility sub debool

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ EXPORTED SUBS
   * `save-yaml($document, :$sorted = True)`
 
   * `save-yamls(**@documents, :$sorted = True)`
+    
+  * `debool(Str $input -> Str)`   #quote boolean values (y, Y, yes, Yes, YES and so on)
 
 TODO
 ====

--- a/lib/YAMLish.rakumod
+++ b/lib/YAMLish.rakumod
@@ -958,6 +958,14 @@ our sub load-yamls(Str $input, ::Grammar:U :$schema = ::Schema::Core, :%tags) is
 	my Callable %callbacks = |%default-tags, |flatten-tags(%tags);
 	return $match ?? $match.ast.map(*.concretize($schema, %callbacks)) !! fail "Couldn't parse YAML";
 }
+our sub debool($s is copy) is export {
+    	my @boolies =  <y Y yes Yes YES n N no No NO
+                   	true True TRUE false False FALSE
+                   	on On ON off Off OFF>;
+
+    $s ~~ s:g/<|w>(<@boolies>)<|w>/\"$0\"/;
+    return $s;
+}
 
 my proto emit-yaml($, $) {*}
 


### PR DESCRIPTION
certain bare strings in .yaml are auto converted by yaml to truthy/falsy values

```
<y Y yes Yes YES n N no No NO
true True TRUE false False FALSE
on On ON off Off OFF>
```

this sub debool can be used thusly to pre-quote these values so that the original string values are imported

```
my $obj = $str.&debool.&load-yaml
```

viz. https://stackoverflow.com/questions/53648244/specifying-the-string-value-yes-in-yaml