### PR TITLE
Fixes for anchors and aliases

### DIFF
--- a/lib/YAMLish.rakumod
+++ b/lib/YAMLish.rakumod
@@ -100,7 +100,7 @@ class Quoted does Single {
 
 class Mapping does Element {
 	has Pair @.elems;
-	submethod BUILD(:@!elems, :$!tag = Tag) {}
+	submethod BUILD(:@!elems, :$!anchor = Str, :$!tag = Tag) {}
 	method make-value($schema, $namespaces, %anchors, %callbacks) {
 		my @pairs := @.elems.map({ .key.concretize($schema, $namespaces, %anchors, %callbacks) => .value.concretize($schema, $namespaces, %anchors, %callbacks)}).list;
 		my $tag = $.effective-tag;
@@ -116,7 +116,7 @@ class Mapping does Element {
 
 class Sequence does Element {
 	has Node @.elems;
-	submethod BUILD(:@!elems, :$!tag = Tag) {}
+	submethod BUILD(:@!elems, :$!anchor = Str, :$!tag = Tag) {}
 	method make-value($schema, $namespaces, %anchors, %callbacks) {
 		my @pairs = @.elems.map(*.concretize($schema, $namespaces, %anchors, %callbacks)).list;
 		my $tag = $.effective-tag;
@@ -335,7 +335,7 @@ grammar Grammar {
 		| <[\?\:\-]> <!before <.space> | <.line-break>>
 	}
 	regex plain(Str $indent) {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		$<value> = [ <.plainfirst> [ <-[\x0a\x0d\:\#]> | ':' <!break> | <!after <.space>> '#' ]* ]
 		[ <.comment>? <value=foldable-plain> $indent ' ' $<value>=[ <-[\x0a\x0d\#]>  | <!after <.space>> '#' ]* ]*
 		<.comment>?
@@ -344,7 +344,7 @@ grammar Grammar {
 		<line-break>+
 	}
 	regex inline-flow-plain {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		$<value> = [
 			<.plainfirst> :
 			[ <-[\x0a\x0d\:\#\,\[\]\{\}]> | ':' <!break> | <!after <.space>> '#' ]*
@@ -353,7 +353,7 @@ grammar Grammar {
 		<.space>*
 	}
 	regex inline-key-plain {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		$<value> = [
 			<.plainfirst> :
 			[ <-[\x0a\x0d\:\#]> | ':' <!break> | <!after <.space>> '#' ]*
@@ -362,16 +362,16 @@ grammar Grammar {
 		<.space>*
 	}
 	token single-key {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		"'" ~ "'" [ <str=single-bare> | <str=single-quotes> | <str=space> ]*
 	}
 	token double-key {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		\" ~ \" [ <str=.quoted-bare> | \\ <str=.quoted-escape> | <str=.space> ]*
 	}
 
 	regex single-quoted {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		"'" ~ "'" [ <str=single-bare> | <str=single-quotes> | <str=foldable-whitespace> | <str=space> ]*
 	}
 	token single-bare {
@@ -381,7 +381,7 @@ grammar Grammar {
 		"''"
 	}
 	token double-quoted {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		\" ~ \" [ <str=.quoted-bare> | \\ <str=.quoted-escape> | <str=foldable-whitespace> | <str=space> ]*
 	}
 	token quoted-bare {
@@ -394,7 +394,7 @@ grammar Grammar {
 		<.space>* [ <breaks=line-break> <.space>* ]+
 	}
 	token block-string(Str $indent) {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		$<kind>=<[\|\>]> $<chomp>=<[+-]>? <.space>*
 		<.comment>? <.line-break>
 		:my $new-indent;
@@ -409,7 +409,7 @@ grammar Grammar {
 	}
 
 	token inline-map {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		'{' <.ws> <pairlist> <.ws> '}'
 	}
 	rule pairlist {
@@ -420,7 +420,7 @@ grammar Grammar {
 	}
 
 	token inline-list {
-		<properties>?
+	        [ <properties> <.space>+ ]?
 		'[' <.ws> <inline-list-inside> <.ws> ']'
 	}
 	rule inline-list-inside {
@@ -443,8 +443,8 @@ grammar Grammar {
 	}
 
 	token properties {
-		| <anchor> <.space>+ [ <tag> <.space>+ ]?
-		| <tag> <.space>+ [ <anchor> <.space>+ ]?
+		| <anchor> [ <.space>+ <tag> ]?
+		| <tag> [ <.space>+ <anchor> ]?
 	}
 
 	token alias {

--- a/t/anchor-alias.t
+++ b/t/anchor-alias.t
@@ -1,0 +1,30 @@
+#!raku
+
+use Test;
+
+use YAMLish;
+
+plan 2;
+
+my $text1 = q:heredoc/END/;
+entries: &entries
+  - one
+  - two
+  - three
+more: *entries
+END
+
+my $d1 = load-yaml($text1);
+is-deeply($d1, ${:entries($["one", "two", "three"]), :more($["one", "two", "three"])},
+          "sequence anchor and alias");
+
+my $text2 = q:heredoc/END/;
+entries: &entries
+  one: value
+  two: value
+more: *entries
+END
+
+my $d2 = load-yaml($text2);
+is-deeply($d2, ${:entries(${:one("value"), :two("value")}), :more(${:one("value"), :two("value")})},
+          "mapping anchor and alias");


### PR DESCRIPTION
Fix anchor parsing when anchor is last thing on line, per the contents of `t/anchor-alias.t`. Fix anchor lookup for Sequence and Mapping.
