### PR TITLE
Fix two latent bugs exposed under the RakuAST frontend

### DIFF
--- a/lib/YAMLish.rakumod
+++ b/lib/YAMLish.rakumod
@@ -515,7 +515,7 @@ grammar Grammar {
 		method directives($/) {
 			my %directives;
 			%directives<tags> = @<tag-directive>».ast.list;
-			%directives<version> = @<yaml-directive>[0].ast.Rat if @<yaml-directives> == 0;
+			%directives<version> = @<yaml-directive>[0]<version>.Str.Rat if @<yaml-directive>;
 			make %directives;
 		}
 		method tag-directive($/) {

--- a/lib/YAMLish.rakumod
+++ b/lib/YAMLish.rakumod
@@ -940,7 +940,7 @@ my sub flatten-tags(%tags) {
 }
 my %default-tags = flatten-tags(%yaml-tags);
 
-our sub load-yaml(Str $input, ::Grammar:U :$schema = ::Schema::Core, :%tags) is export {
+our sub load-yaml(Str $input, ::GrammarType:U :$schema = ::Schema::Core, :%tags) is export {
 	my $match = Grammar.parse($input);
 	CATCH {
 		fail "Couldn't parse YAML: $_";
@@ -948,7 +948,7 @@ our sub load-yaml(Str $input, ::Grammar:U :$schema = ::Schema::Core, :%tags) is 
 	my Callable %callbacks = |%default-tags, |flatten-tags(%tags);
 	return $match ?? $match.ast[0].concretize($schema, %callbacks) !! fail "Couldn't parse YAML";
 }
-our sub load-yamls(Str $input, ::Grammar:U :$schema = ::Schema::Core, :%tags) is export {
+our sub load-yamls(Str $input, ::GrammarType:U :$schema = ::Schema::Core, :%tags) is export {
 	my $match = Grammar.parse($input);
 	CATCH {
 		fail "Couldn't parse YAML: $_";
@@ -1073,8 +1073,8 @@ $ zef install YAMLish
 
 =head1 EXPORTED SUBS
 
-=item C<load-yaml(Str $input, ::Grammar:U :$schema = ::Schema::Core, :%tags)>
-=item C<load-yamls(Str $input, ::Grammar:U :$schema = ::Schema::Core, :%tags)>
+=item C<load-yaml(Str $input, ::GrammarType:U :$schema = ::Schema::Core, :%tags)>
+=item C<load-yamls(Str $input, ::GrammarType:U :$schema = ::Schema::Core, :%tags)>
 =item C<save-yaml($document, :$sorted = True)>
 =item C<save-yamls(**@documents, :$sorted = True)>
 

--- a/t/basic.rakutest
+++ b/t/basic.rakutest
@@ -112,4 +112,10 @@ END
 my $expected4 = "1";
 is(load-yaml($text4), $expected4, 'Tags and directives seem to work');
 
+# A %YAML directive sets the document version; its absence defaults it.
+is(YAMLish::Grammar.parse("%YAML 1.1\n---\nkey: value\n").ast[0].version, 1.1,
+	'%YAML directive sets the document version');
+is(YAMLish::Grammar.parse("---\nkey: value\n").ast[0].version, 1.2,
+	'absent %YAML directive defaults the document version');
+
 done-testing();


### PR DESCRIPTION
Both of these are pre-existing YAMLish bugs that only surface once the module is parsed under the RakuAST grammar frontend. Neither is a rakudo bug. The RakuAST behavior is correct in both cases, legacy was just masking them.

The first commit renames a type capture in `load-yaml`/`load-yamls`. `::Grammar:U :$schema` introduced a lexical `Grammar` that shadowed the actual `grammar Grammar`, so under RakuAST `Grammar.parse` ended up running the schema grammar instead of the YAML one and you'd hit `No such method 'concretize'`. The captured type was never used for anything, so it just gets a name that doesn't collide.

The second commit fixes version extraction in the `directives` action. It pulled the version off `.ast` (always Nil, the token has no action method) behind a misspelled guard that happened to skip the branch on legacy but ran it under RakuAST. Now it reads the real `$<version>` subcapture.
